### PR TITLE
Fix cron issue

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
 SHELL=/bin/bash
-0 22 * * * /app/rebuild.py >> /dev/pts/0 2>&1
+0 22 * * * /app/rebuild.py >> /build/log

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -ex
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+if [[ $(docker ps -a | grep "meatballs") ]]; then
+	docker rm -f meatballs
+fi
+docker rmi meatballs
+
+docker pull antonhager/meatballs:latest
+docker run -d \
+	--name meatballs \
+	--network meatballs \
+	--restart always \
+	--label "traefik.enable=true" \
+	--label "traefik.http.middlewares.https-redirect.redirectscheme.scheme=https" \
+	--label "traefik.http.routers.meatballs-http.entrypoints=web" \
+	--label "traefik.http.routers.meatballs-http.rule=Host(\`istodaymeatballsday.com\`)" \
+	--label "traefik.http.routers.meatballs-http.middlewares=https-redirect" \
+	--label "traefik.http.routers.meatballs.entrypoints=web-secure" \
+	--label "traefik.http.routers.meatballs.rule=Host(\`istodaymeatballsday.com\`)" \
+	--label "traefik.http.routers.meatballs.tls=true" \
+	--label "traefik.http.routers.meatballs.tls.certresolver=anton-pizza" \
+	antonhager/meatballs:latest


### PR DESCRIPTION
The whole cron problem was that I redirected the output to the tty 0. Apparently this doesn't work when tty 0 doesn't exist (surprise). What I guess I would need to do to get this to work as I expected is to redirect the output of the script to stdout of the init process. To get around all this shit I simply dont do it and instead redirect the output to a log file (/build/log). 

This pr will:
- Redirect the logs of `rebuild.py` to /build/log instead of tty 0
- Add the script used for restarting a new version of the container and remove the old ones. (The old image is removed from the vm since I dont want to pay for ssd storage of old images)